### PR TITLE
fix: ignore key release events on user input

### DIFF
--- a/src/ui/event_handler.rs
+++ b/src/ui/event_handler.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{self, Event, KeyCode, KeyModifiers};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use std::time::Duration;
 
 use super::audio_preferences_screen::AudioPreferencesScreen;
@@ -59,6 +59,12 @@ impl AppEventHandler {
 
     fn handle_user_input(app: &mut App) -> Result<bool, Box<dyn std::error::Error>> {
         if let Event::Key(key) = event::read()? {
+            // Ignore key release events to avoid duplicate handling on terminals
+            // that emit both press and release for a single keystroke.
+            if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+                return Ok(false);
+            }
+
             // Ctrl+S: save project (only in DAW screen)
             if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('s') {
                 if matches!(app.screen, Screen::Daw { .. }) {


### PR DESCRIPTION
Muchachos, quedé muy copado con la demo y quise probar el proyecto en Windows. Cuando lo corrí me encontré con este pequeño bug:

Cuando presionás una tecla, Windows emite un evento de tipo `Press` (o `Repeat` cuando dejás apretada la tecla) y también emite uno de tipo `Release`. Se ve que en mac esto no pasa. Como el handler no filtra estos tipos de eventos, interpreta que un evento de tipo Release significa que volviste a tocar la misma tecla de vuelta.

Este fix lo que hace es ignorar los eventos que no sean de tipo `KeyEventKind::Press` o `KeyEventKind::Repeat`. Probé en Mac y no rompe nada. En Linux no lo pude correr ni antes del fix, pero igual ahí no anda ni la scarlett así que asumo que no es un problema 👁️ 

| Antes | Después |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/b2e5cf59-fdd4-4cd5-b89a-80956743c258"> | <video src="https://github.com/user-attachments/assets/16cec51d-a3f5-4089-8e92-d98f83579388"> |